### PR TITLE
docs(orders): ORDERS-4524 digital and gift certificate discussion

### DIFF
--- a/reference/digital-consignments.json
+++ b/reference/digital-consignments.json
@@ -1,0 +1,58 @@
+{
+  "Option_1": {
+    "digital": [
+      {
+        "lineItems": [
+          {
+            "id": 7
+          }
+        ],
+        "email": "abc@bigcommerce.com",
+        "type": "gift-certificate"
+      },
+      {
+        "lineItems": [
+          {
+            "id": 8
+          }
+        ],
+        "email": "zyz@bigcommerce.com",
+        "type": "product"
+      }
+    ],
+    "pickup": {
+      "..": "etc"
+    },
+    "shipping": {
+      "..": "etc"
+    }
+  },
+  "Option_2": {
+    "digital": [
+      {
+        "lineItems": [
+          {
+            "id": 8
+          }
+        ],
+        "email": "zyz@bigcommerce.com"
+      }
+    ],
+    "giftCertificate": [
+      {
+        "lineItems": [
+          {
+            "id": 7
+          }
+        ],
+        "email": "abc@bigcommerce.com"
+      }
+    ],
+    "pickup": {
+      "..": "etc"
+    },
+    "shipping": {
+      "..": "etc"
+    }
+  }
+}

--- a/reference/orders-v2-consignments-update.json
+++ b/reference/orders-v2-consignments-update.json
@@ -1,0 +1,174 @@
+{
+  "Current": {
+    "consignments": {
+      "pickup": [
+        {
+          "id": 19,
+          "line_items": {
+            "url": "https://api-proxy.service.bcdev/stores/txy6nw8xqz/v2/orders/133/products",
+            "resource": "/api/v2/orders/133/products"
+          },
+          "fulfillment_method": {
+            "pickup": {
+              "pickup_method_id": 10,
+              "pickup_method_display_name": "Pickup Method 10: Pickup at Location 1",
+              "collection_instructions": "Pickup Method 10 Collection Instructions",
+              "collection_time_description": "Pickup Method 10 Collection Time Description",
+              "location": {
+                "id": 1,
+                "name": "Default location",
+                "address_line_1": "123 main street",
+                "address_line_2": "",
+                "city": "Austin",
+                "state": "TX",
+                "postal_code": "111111",
+                "country_alpha2": "US",
+                "email": "default@exmaple.com",
+                "phone": "+1 1111111111"
+              }
+            },
+            "digital": null,
+            "delivery": null
+          }
+        }
+      ],
+      "shipping": [
+        {
+          "id": 3,
+          "status": "SHIPPED",
+          "line_items": [
+            {
+              "url": "http://localhost:3100/v2/orders/133/products/93",
+              "resource": "/api/v2/orders/133/orders/133/products"
+            }
+          ],
+          "fulfillment_method": {
+            "pickup": null,
+            "digital": null,
+            "delivery": {
+              "shipping_address_id": 5,
+              "company": "Acme Pty Ltd",
+              "street_1": "Appartment 13",
+              "street_2": "12 Main St",
+              "city": "Sydney",
+              "zip": "2001",
+              "country": "Australis",
+              "country_iso2": "AU",
+              "state": "NSW",
+              "email": "joe@mycompany.com",
+              "phone": "02 3456 7899",
+              "order_id": 7,
+              "first_name": "Trisha",
+              "last_name": "McLaughlin",
+              "items_total": 3,
+              "items_shipped": 2,
+              "base_cost": "27.0000",
+              "cost_ex_tax": "27.0000",
+              "cost_inc_tax": "30.0000",
+              "cost_tax": "3.0000",
+              "cost_tax_class_id": 7,
+              "base_handling_cost": "4.0000",
+              "handling_cost_ex_tax": "4.0000",
+              "handling_cost_inc_tax": "5.0000",
+              "handling_cost_tax": "1.0000",
+              "handling_cost_tax_class_id": 4,
+              "shipping_zone_id": 62,
+              "shipping_zone_name": "Australia",
+              "shipping_quotes": {
+                "url": "https://acme.com/api/v2/orders/133/shipping_addresses/5/shipping_quotes.json",
+                "resource": "/api/v2/orders/133/shipping_addresses/5/shipping_quotes"
+              },
+              "form_fields": [],
+              "links": [
+                {
+                  "url": "https://api.bigcommerce.com/stores/{$$.env.store_hash}/v2/orders/100/consignments/3/pickup",
+                  "resource": "/orders/100/consignments/1/delivery"
+                },
+                {
+                  "url": "https://api.bigcommerce.com/stores/{$$.env.store_hash}/v2/orders/100/consignments/1/fulfillment_method",
+                  "resource": "/orders/100/consignments/1/fulfillment_method"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Proposed": {
+      "consignments": {
+        "digital": {
+          "similar to what we decide for storefront": ""
+        },
+        "pickup": {
+          "pickup_method_id": 10,
+          "pickup_method_display_name": "Pickup Method 10: Pickup at Location 1",
+          "collection_instructions": "Pickup Method 10 Collection Instructions",
+          "collection_time_description": "Pickup Method 10 Collection Time Description",
+          "location": {
+            "id": 1,
+            "name": "Default location",
+            "address_line_1": "123 main street",
+            "address_line_2": "",
+            "city": "Austin",
+            "state": "TX",
+            "postal_code": "111111",
+            "country_alpha2": "US",
+            "email": "default@exmaple.com",
+            "phone": "+1 1111111111"
+          },
+          "line_items": [
+            {
+              "url": "http://localhost:3100/v2/orders/133/products/99"
+            },
+            {
+              "url": "http://localhost:3100/v2/orders/133/products/100"
+            }
+          ]
+        },
+        "shipping": [
+          {
+            "shippingAddressId": 1,
+            "firstName": "first1",
+            "lastName": "last1",
+            "company": "company1",
+            "address1": "2802 Skyway Cir",
+            "address2": "Balcony",
+            "city": "Austin",
+            "stateOrProvince": "Texas",
+            "postalCode": "78704",
+            "country": "United States",
+            "countryCode": "US",
+            "email": "first1@bigcommerce.com",
+            "phone": "0410123452",
+            "itemsTotal": 1,
+            "itemsShipped": 0,
+            "shippingMethod": "Flat Rate",
+            "baseCost": 15.5,
+            "costExTax": 15.5,
+            "costIncTax": 16.7,
+            "costTax": 1.2,
+            "costTaxClassId": 2,
+            "baseHandlingCost": 0,
+            "handlingCostExTax": 0,
+            "handlingCostIncTax": 0,
+            "handlingCostTax": 0,
+            "handlingCostTaxClassId": 2,
+            "shippingZoneId": 1,
+            "shippingZoneName": "United States",
+            "customFields": [
+              {
+                "name": "special note",
+                "value": "super rare"
+              }
+            ],
+            "lineItems": [
+              {
+                "url": "http://localhost:3100/v2/orders/133/products/93"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION

# Should we  model gift certificates and digital downloads as consignments in storefront orders API
## No
### Pro
Consistent with checkout which doesn't model them as consignments

Consideration, should we do this also for `/v2/orders`?

### Work Required
None

## Yes 
### Pros
- Provide  API clients  a single place to discover how all of  the line-items on the order are being fulfilled, rather than looking for pickups and shipping under `/consignments` and then having to know to have to look under the `/cart/lineItems/digitalItems` for the digital items

### Cons
- public API contract so if we add it now we lock ourselves into supporting it long-term
- inconsistent with checkout 


### Work required
1. add `order_product` gift certificate id to  `/cart/lineItems/giftcertificates`
2. decide on format
3. update storefront api


# Proposed simplification of api payload

## Current
```
 "pickup": [
        {
          "id": 19,
          "line_items": {
            "url": "https://api-proxy.service.bcdev/stores/txy6nw8xqz/v2/orders/133/products",
            "resource": "/api/v2/orders/133/products"
          },
          "fulfillment_method": {
            "pickup": {
              "pickup_method_id": 10,
              "pickup_method_display_name": "Pickup Method 10: Pickup at Location 1",
              "collection_instructions": "Pickup Method 10 Collection Instructions",
              "collection_time_description": "Pickup Method 10 Collection Time Description",
              "location": {
                "id": 1,..
}
```

